### PR TITLE
Remove weekly build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,6 @@ on:
       - opened
       - synchronize
       - reopened
-  schedule:
-    - cron: "0 10 * * 5" # JST 19:00 (Fri)
 
 jobs:
   test:


### PR DESCRIPTION
Workaround for action to stop in 60 days

c.f. https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#disabling-and-enabling-workflows